### PR TITLE
Use case-sensitive keys

### DIFF
--- a/internal/encoding/dotenv/map_utils.go
+++ b/internal/encoding/dotenv/map_utils.go
@@ -1,8 +1,6 @@
 package dotenv
 
 import (
-	"strings"
-
 	"github.com/spf13/cast"
 )
 
@@ -31,7 +29,7 @@ func flattenAndMergeMap(shadow map[string]interface{}, m map[string]interface{},
 			m2 = cast.ToStringMap(val)
 		default:
 			// immediate value
-			shadow[strings.ToLower(fullKey)] = val
+			shadow[fullKey] = val
 			continue
 		}
 		// recursively merge to shadow map

--- a/internal/encoding/ini/map_utils.go
+++ b/internal/encoding/ini/map_utils.go
@@ -1,8 +1,6 @@
 package ini
 
 import (
-	"strings"
-
 	"github.com/spf13/cast"
 )
 
@@ -64,7 +62,7 @@ func flattenAndMergeMap(shadow map[string]interface{}, m map[string]interface{},
 			m2 = cast.ToStringMap(val)
 		default:
 			// immediate value
-			shadow[strings.ToLower(fullKey)] = val
+			shadow[fullKey] = val
 			continue
 		}
 		// recursively merge to shadow map

--- a/internal/encoding/javaproperties/codec.go
+++ b/internal/encoding/javaproperties/codec.go
@@ -67,7 +67,7 @@ func (c *Codec) Decode(b []byte, v map[string]interface{}) error {
 
 		// recursively build nested maps
 		path := strings.Split(key, c.keyDelimiter())
-		lastKey := strings.ToLower(path[len(path)-1])
+		lastKey := path[len(path)-1]
 		deepestMap := deepSearch(v, path[0:len(path)-1])
 
 		// set innermost value

--- a/internal/encoding/javaproperties/map_utils.go
+++ b/internal/encoding/javaproperties/map_utils.go
@@ -1,8 +1,6 @@
 package javaproperties
 
 import (
-	"strings"
-
 	"github.com/spf13/cast"
 )
 
@@ -64,7 +62,7 @@ func flattenAndMergeMap(shadow map[string]interface{}, m map[string]interface{},
 			m2 = cast.ToStringMap(val)
 		default:
 			// immediate value
-			shadow[strings.ToLower(fullKey)] = val
+			shadow[fullKey] = val
 			continue
 		}
 		// recursively merge to shadow map


### PR DESCRIPTION
Viper handles keys in a case-insensitive manner by lower-casing all keys.

This change makes viper case-sensitive by treating keys as-is.

If you'd like to test this PR against saucectl, simply add the following line above your `require` statements in go.mod:
```
replace github.com/spf13/viper => github.com/saucelabs/viper v0.0.0-20221203011248-6cac6d858335
```